### PR TITLE
Re-order color scheme includes

### DIFF
--- a/colors.xml
+++ b/colors.xml
@@ -39,26 +39,6 @@
     <systemProgressbarSelectorColor>999999</systemProgressbarSelectorColor>
   </variables>
 
-  <variables ifSubset="color-scheme:retro">
-    <helpTextColor>ffffff</helpTextColor>
-    <systemInfoColor>ffffff</systemInfoColor>
-    <systemCarouselSelectorColor>dbba70</systemCarouselSelectorColor>
-    <gamelistLogoColor>f7cd6e</gamelistLogoColor>
-    <gamelistBackgroundImage>gamelist-background-retro</gamelistBackgroundImage>
-    <gamelistMetadataBackgroundImage>gamelist-metadata-background-retro</gamelistMetadataBackgroundImage>
-    <gamelistSelectorColor>3b290d</gamelistSelectorColor>
-    <gamelistSelectedColor>ffffff</gamelistSelectedColor>
-    <gamelistPrimaryColor>3b290d</gamelistPrimaryColor>
-    <gamelistSecondaryColor>3b290d</gamelistSecondaryColor>
-    <gameMetadataColor>3b290d</gameMetadataColor>
-    <BackdropColor>291c0a</BackdropColor>
-    <backgroundArtPath>${themePath}/wallpapers/retro</backgroundArtPath>
-    <menuBackgroundColor>ac9358</menuBackgroundColor>
-    <menuBackgroundColorTitle>887852</menuBackgroundColorTitle>
-    <menuTextColor>3b290d</menuTextColor>
-    <systemProgressbarSelectorColor>9e8444</systemProgressbarSelectorColor>
-  </variables>
-
   <variables ifSubset="color-scheme:neon">
     <helpTextColor>FFFFFF</helpTextColor>
     <systemInfoColor>FFFFFF</systemInfoColor>
@@ -177,5 +157,25 @@
     <menuBackgroundColorTitle>faf1c5</menuBackgroundColorTitle>
     <menuTextColor>5b5a58</menuTextColor>
     <systemProgressbarSelectorColor>93cbb7</systemProgressbarSelectorColor>
+  </variables>
+
+  <variables ifSubset="color-scheme:retro">
+    <helpTextColor>ffffff</helpTextColor>
+    <systemInfoColor>ffffff</systemInfoColor>
+    <systemCarouselSelectorColor>dbba70</systemCarouselSelectorColor>
+    <gamelistLogoColor>f7cd6e</gamelistLogoColor>
+    <gamelistBackgroundImage>gamelist-background-retro</gamelistBackgroundImage>
+    <gamelistMetadataBackgroundImage>gamelist-metadata-background-retro</gamelistMetadataBackgroundImage>
+    <gamelistSelectorColor>3b290d</gamelistSelectorColor>
+    <gamelistSelectedColor>ffffff</gamelistSelectedColor>
+    <gamelistPrimaryColor>3b290d</gamelistPrimaryColor>
+    <gamelistSecondaryColor>3b290d</gamelistSecondaryColor>
+    <gameMetadataColor>3b290d</gameMetadataColor>
+    <BackdropColor>291c0a</BackdropColor>
+    <backgroundArtPath>${themePath}/wallpapers/retro</backgroundArtPath>
+    <menuBackgroundColor>ac9358</menuBackgroundColor>
+    <menuBackgroundColorTitle>887852</menuBackgroundColorTitle>
+    <menuTextColor>3b290d</menuTextColor>
+    <systemProgressbarSelectorColor>9e8444</systemProgressbarSelectorColor>
   </variables>
 </theme>

--- a/theme.xml
+++ b/theme.xml
@@ -27,8 +27,8 @@ License: Creative Commons CC-BY-NC-SA
 
 	<!-- Subset: System View Options -->
 	<subset name="system-view" displayName="System View">
-		<include name="carousel" displayName="Carousel" />
 		<include name="grid" displayName="Grid" />
+		<include name="carousel" displayName="Carousel" />
 	</subset>
 
 	<!-- Subset: System Grid Sizes -->
@@ -53,10 +53,10 @@ License: Creative Commons CC-BY-NC-SA
 
 	<!-- Subset: Color Scheme -->
 	<subset name="color-scheme" displayName="Color Scheme">
+    <include name="retro" displayName="Retro" />
     <include name="default" displayName="Default" />
     <include name="dark" displayName="Dark" />
     <include name="light" displayName="Light" />
-    <include name="retro" displayName="Retro" />
     <include name="neon" displayName="Neon" />
     <include name="pastel" displayName="Pastel" />
     <include name="sony" displayName="Sony" />


### PR DESCRIPTION
Move the retro color scheme definition to the end of the list to match
the order in colors.xml.

Signed-off-by: Juliano Dorigão <jdorigao@gmail.com>
